### PR TITLE
qol-and-fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Larva is the Frank!Framework's built-in test tool. Tests live in `src/test/testt
 **Running tests**
 
 1. Start the application with Frank!Runner (`.\restart.bat` / `./restart.sh`)
-2. Open the Frank!Console at `https://localhost` (accept the self-signed certificate warning)
+2. Open the Frank!Console at `http://localhost:8080`
 3. Navigate to **Testing → Larva**
 4. Select the scenario folder and click **Run**
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ docker-compose up
 
 This will start:
 - **Frank Application**: Available at `http://localhost:8080`
-- **Frank Flow (UI)**: Available at `http://localhost:8090`
+- **Frank Flow (UI)**: Available at `http://localhost:8080/frank-flow`
 - **PostgreSQL Database**: Exposed on host port `5433` (internal: 5432)
 
 ## Configuration Files

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ From the project root in the terminal run:
 ```
 
 The application will be available at:
-- HTTP: `http://localhost:8080` (redirects to HTTPS)
-- HTTPS: `https://localhost` (self-signed certificate — accept the browser warning on first visit)
+- `http://localhost:8080`
+
+> **Note:** HTTPS is disabled by default because requests from Open Zaak do not reach the NC when HTTPS is enabled. To enable HTTPS, set `application.security.http.transportGuarantee=confidential` in `DeploymentSpecifics.properties`.
 
 ### Docker Deployment
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,15 +16,6 @@ services:
       db:
         condition: service_healthy
 
-  frank-flow:
-    image: frankframework/frank-flow:latest
-    environment:
-      configurations.directory: /opt/frank/configurations
-    volumes:
-      - ./src/main/:/opt/frank/:rw
-    ports:
-      - "8090:8090"
-
   db:
     image: postgres:15
     environment:

--- a/frank-runner.properties
+++ b/frank-runner.properties
@@ -1,5 +1,5 @@
 #ff.version=10.0.0
-tomcat.connector.port=8070
+tomcat.connector.port=8080
 
 dtap.stage=LOC
 #dtap.stage=DEV

--- a/frank-runner.properties
+++ b/frank-runner.properties
@@ -1,5 +1,5 @@
 #ff.version=10.0.0
-tomcat.connector.port=8080
+tomcat.connector.port=8070
 
 dtap.stage=LOC
 #dtap.stage=DEV

--- a/src/main/resources/DeploymentSpecifics.properties
+++ b/src/main/resources/DeploymentSpecifics.properties
@@ -10,6 +10,8 @@ nc.api.base-url=https://localhost/api/v1
 jdbc.migrator.active=true
 jdbc.datasource.default=jdbc/notificatiecomponent
 application.security.jwt.allowWeakSecrets=true
+
+# It is preferable to use HTTPS in production, but requests from Open Zaak do not reach the NC.
 #application.security.http.transportGuarantee=confidential
 application.security.http.transportGuarantee=none
 

--- a/src/main/resources/DeploymentSpecifics.properties
+++ b/src/main/resources/DeploymentSpecifics.properties
@@ -10,7 +10,8 @@ nc.api.base-url=https://localhost/api/v1
 jdbc.migrator.active=true
 jdbc.datasource.default=jdbc/notificatiecomponent
 application.security.jwt.allowWeakSecrets=true
-application.security.http.transportGuarantee=confidential
+#application.security.http.transportGuarantee=confidential
+application.security.http.transportGuarantee=none
 
 # Base URL of the autorisaties API from Open Zaak. Override in .env for Docker (use host.docker.internal).
 nc.zgw.autorisaties-api.root-url=http://localhost:8001/autorisaties/api/v1


### PR DESCRIPTION
Reverted back to HTTP (by default) as requests from Open Zaak do not reach the NC over HTTPS